### PR TITLE
amf3::encode: Add Encoder::inner, make encode_utf8 public

### DIFF
--- a/src/amf3/encode.rs
+++ b/src/amf3/encode.rs
@@ -15,8 +15,12 @@ impl<W> Encoder<W> {
     pub fn into_inner(self) -> W {
         self.inner
     }
-    /// Returns a reference to the underlying writer.
-    pub fn inner(&mut self) -> &mut W {
+    /// Returns an immutable reference to the underlying writer.
+    pub fn inner(&self) -> &W {
+        &self.inner
+    }
+    /// Returns a mutable reference to the underlying writer.
+    pub fn inner_mut(&mut self) -> &mut W {
         &mut self.inner
     }
 }

--- a/src/amf3/encode.rs
+++ b/src/amf3/encode.rs
@@ -15,6 +15,10 @@ impl<W> Encoder<W> {
     pub fn into_inner(self) -> W {
         self.inner
     }
+    /// Returns a reference to the underlying writer.
+    pub fn inner(&mut self) -> &mut W {
+        &mut self.inner
+    }
 }
 impl<W> Encoder<W>
 where
@@ -268,7 +272,11 @@ where
         }
         Ok(())
     }
-    fn encode_utf8(&mut self, s: &str) -> io::Result<()> {
+    /// Encode an AMF3 string.
+    ///
+    /// Use this if you need to decode an AMF3 string outside of value context.
+    /// An example of this is writing keys in Local Shared Object file.
+    pub fn encode_utf8(&mut self, s: &str) -> io::Result<()> {
         self.encode_size(s.len())?;
         self.inner.write_all(s.as_bytes())?;
         Ok(())

--- a/src/amf3/encode.rs
+++ b/src/amf3/encode.rs
@@ -274,7 +274,7 @@ where
     }
     /// Encode an AMF3 string.
     ///
-    /// Use this if you need to decode an AMF3 string outside of value context.
+    /// Use this if you need to encode an AMF3 string outside of value context.
     /// An example of this is writing keys in Local Shared Object file.
     pub fn encode_utf8(&mut self, s: &str) -> io::Result<()> {
         self.encode_size(s.len())?;


### PR DESCRIPTION
This is in the same vein as the previous commit that did this to Decoder.
Having these methods available assists in writing a .sol file encoder.