### PR TITLE
Add encoded_len() to calculate buffer size upfront before writing.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,3 +16,11 @@ coveralls = {repository = "sile/amf"}
 
 [dependencies]
 byteorder = "1"
+
+
+[dev-dependencies]
+criterion = "0.3"
+
+[[bench]]
+name = "alloc"
+harness = false

--- a/benches/alloc.rs
+++ b/benches/alloc.rs
@@ -1,0 +1,46 @@
+use criterion::{criterion_group, criterion_main, BenchmarkId, Criterion};
+extern crate amf;
+
+use amf::amf0::Value;
+
+fn write_to_vec_new(value: &Value) {
+    let mut buf = Vec::new();
+    value.write_to(&mut buf).unwrap();
+}
+
+fn write_to_vec_with_capacity(value: &Value) {
+    let mut buf = Vec::with_capacity(value.encoded_len());
+    value.write_to(&mut buf).unwrap();
+}
+
+fn criterion_benchmark(c: &mut Criterion) {
+    let mut group = c.benchmark_group("allocations");
+
+    let boolean = Value::Boolean(false);
+    let string = Value::String("Hello!".to_string());
+    let number = Value::Number(10.0);
+    let date = Value::Date { unix_time: std::time::Duration::from_millis(0), time_zone:0 };
+    let array = Value::Array {
+        entries: vec![
+            Value::Number(20.0),
+            Value::String("Hello!".to_string()),
+            Value::Boolean(true),
+            Value::Date { unix_time: std::time::Duration::from_millis(0), time_zone:0 }
+        ],
+    };
+
+    let names = ["boolean", "string", "number", "date", "array"];
+    for (x, i) in [boolean, string, number, date, array].iter().enumerate() {
+        group.bench_with_input(BenchmarkId::new(names[x], "vec_new"), i, |b, i| {
+            b.iter(|| write_to_vec_new(i))
+        });
+        group.bench_with_input(
+            BenchmarkId::new(names[x], "vec_with_capacity"),
+            i,
+            |b, i| b.iter(|| write_to_vec_with_capacity(i)),
+        );
+    }
+}
+
+criterion_group!(benches, criterion_benchmark);
+criterion_main!(benches);

--- a/src/amf0/mod.rs
+++ b/src/amf0/mod.rs
@@ -134,6 +134,10 @@ pub enum Value {
     AvmPlus(amf3::Value),
 }
 impl Value {
+    /// Calculates the length of an encoded value in bytes.
+    pub fn encoded_len(&self) -> usize {
+        encode::encoded_len(&self)
+    }
     /// Reads an AMF0 encoded `Value` from `reader`.
     ///
     /// Note that reference objects are copied in the decoding phase

--- a/src/amf3/mod.rs
+++ b/src/amf3/mod.rs
@@ -188,6 +188,11 @@ pub enum Value {
     },
 }
 impl Value {
+    /// Calculates the length of an encoded value in bytes.
+    pub fn encoded_len(&self) -> usize {
+        encode::encoded_len(&self)
+    }
+
     /// Reads an AMF3 encoded `Value` from `reader`.
     ///
     /// Note that reference objects are copied in the decoding phase

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -52,6 +52,13 @@ pub enum Value {
     Amf3(Amf3Value),
 }
 impl Value {
+    /// Calculates the length of an encoded value in bytes.
+    pub fn encoded_len(&self) -> usize {
+        match *self {
+            Value::Amf0(ref x) => x.encoded_len(),
+            Value::Amf3(ref x) => x.encoded_len(),
+        }
+    }
     /// Reads an AMF encoded `Value` from `reader`.
     ///
     /// Note that reference objects are copied in the decoding phase


### PR DESCRIPTION
Hello,

I'm learning rust. For learning project I pick yours awesome library.  I had idea that upfront vec capacity size will improve performance. And quick tests showed it does:

```
allocations/boolean/vec_new                                                                             
                        time:   [47.646 ns 47.755 ns 47.867 ns]
                        change: [+1.3173% +1.6049% +1.9144%] (p = 0.00 < 0.05)
                        Performance has regressed.
Found 2 outliers among 100 measurements (2.00%)
  2 (2.00%) high mild
allocations/boolean/vec_with_capacity                                                                             
                        time:   [46.440 ns 46.771 ns 47.277 ns]
                        change: [+2.2083% +2.6621% +3.1818%] (p = 0.00 < 0.05)
                        Performance has regressed.
Found 1 outliers among 100 measurements (1.00%)
  1 (1.00%) high severe
allocations/string/vec_new                                                                            
                        time:   [109.46 ns 109.72 ns 109.99 ns]
                        change: [+3.5553% +3.8322% +4.1142%] (p = 0.00 < 0.05)
                        Performance has regressed.
Found 3 outliers among 100 measurements (3.00%)
  2 (2.00%) high mild
  1 (1.00%) high severe
allocations/string/vec_with_capacity                                                                            
                        time:   [73.917 ns 76.041 ns 79.581 ns]
                        change: [-1.4476% +0.7508% +4.3049%] (p = 0.65 > 0.05)
                        No change in performance detected.
Found 9 outliers among 100 measurements (9.00%)
  1 (1.00%) low mild
  4 (4.00%) high mild
  4 (4.00%) high severe
allocations/number/vec_new                                                                            
                        time:   [96.072 ns 96.251 ns 96.433 ns]
                        change: [+2.7100% +3.1747% +3.6512%] (p = 0.00 < 0.05)
                        Performance has regressed.
Found 6 outliers among 100 measurements (6.00%)
  2 (2.00%) high mild
  4 (4.00%) high severe
allocations/number/vec_with_capacity                                                                             
                        time:   [46.674 ns 46.770 ns 46.864 ns]
                        change: [+2.6973% +3.0705% +3.4308%] (p = 0.00 < 0.05)
                        Performance has regressed.
Found 7 outliers among 100 measurements (7.00%)
  1 (1.00%) low severe
  2 (2.00%) low mild
  3 (3.00%) high mild
  1 (1.00%) high severe
allocations/date/vec_new                                                                            
                        time:   [95.760 ns 96.073 ns 96.433 ns]
                        change: [+0.9027% +2.1367% +3.1105%] (p = 0.00 < 0.05)
                        Change within noise threshold.
Found 12 outliers among 100 measurements (12.00%)
  1 (1.00%) low mild
  6 (6.00%) high mild
  5 (5.00%) high severe
allocations/date/vec_with_capacity                                                                             
                        time:   [49.408 ns 49.771 ns 50.171 ns]
                        change: [+5.7604% +6.4634% +7.2062%] (p = 0.00 < 0.05)
                        Performance has regressed.
Found 4 outliers among 100 measurements (4.00%)
  3 (3.00%) high mild
  1 (1.00%) high severe
allocations/array/vec_new                                                                            
                        time:   [265.23 ns 265.96 ns 266.81 ns]
                        change: [+0.5339% +0.8979% +1.2369%] (p = 0.00 < 0.05)
                        Change within noise threshold.
Found 4 outliers among 100 measurements (4.00%)
  2 (2.00%) high mild
  2 (2.00%) high severe
allocations/array/vec_with_capacity                                                                            
                        time:   [112.10 ns 112.80 ns 113.69 ns]
                        change: [+0.3537% +0.7904% +1.2610%] (p = 0.00 < 0.05)
                        Change within noise threshold.
Found 8 outliers among 100 measurements (8.00%)
  1 (1.00%) low severe
  2 (2.00%) low mild
  5 (5.00%) high severe
```