### PR TITLE
Add 'inner' and 'inner_mut' variant for 'amf0::decode::Decoder'

### DIFF
--- a/src/amf0/decode.rs
+++ b/src/amf0/decode.rs
@@ -18,6 +18,16 @@ impl<R> Decoder<R> {
     pub fn into_inner(self) -> R {
         self.inner
     }
+
+    /// Get the reference to the underlying reader.
+    pub fn inner(&self) -> &R {
+        &self.inner
+    }
+
+    /// Get the mutable reference to the underlying reader.
+    pub fn inner_mut(&mut self) -> &mut R {
+        &mut self.inner
+    }
 }
 impl<R> Decoder<R>
 where


### PR DESCRIPTION
Hello,

Currently I uses `inner` to get the `amf0::decode::Decoder` since I need to know if the underlying buffer is empty, so I think it might be useful for upstream

```rust
let mut decoder = amf::amf0::Decoder::new(&data[..]);
loop {
    if decoder.inner().is_empty() {
        break;
    }
    match Self::decode_amf0::<_, 18>(&mut decoder) {
        Ok(val) => { /* ... */ }
        Err(e) => { /* ... */ }
    }
}
```